### PR TITLE
docs: rename Development.md to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Development
+# Contributing
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ A replacement of the definitions functionality from the original Atom-IDE / Nucl
 
   You can also search for [packages](https://atom.io/packages/search?q=IDE) in Atom.
 
-## Development
+## Contributing
 
-Please see [Development.md](./Development.md)
+Please see the [contributing guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
This way we can take advantage of the contributing guidelines feature.

https://github.blog/2012-09-17-contributing-guidelines/

Since many of these package will behave in similarly we could use the new [organization-wide community health files feature](https://github.blog/changelog/2019-02-21-organization-wide-community-health-files/). What do you think?