### PR TITLE
feat: add hyperclick provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ A replacement of the definitions functionality from the original Atom-IDE / Nucl
 
   You can also search for [packages](https://atom.io/packages/search?q=IDE) in Atom.
 
+3. (Optional) Install [hyperclick](https://atom.io/packages/hyperclick) for `cmd/ctrl+click` support  
+  You can set [priority and grammar scope](https://github.com/facebookarchive/hyperclick#details) in extension settings
+
 ## Contributing
 
 Please see the [contributing guidelines](CONTRIBUTING.md).

--- a/lib/clickProvider.js
+++ b/lib/clickProvider.js
@@ -1,0 +1,35 @@
+'use babel';
+
+export class ClickProvider {
+  constructor(options) {
+    this.clickHandler = options.clickHandler;
+
+    this.suggestionForWordHandler = this.suggestionForWordHandler.bind(this);
+    this.getProvider = this.getProvider.bind(this);
+  }
+
+  suggestionForWordHandler(textEditor, text, range) {
+    const targetValue = text && text.trim();
+    if (!targetValue) return;
+
+    return {
+      range,
+      callback: () => this.clickHandler(),
+    };
+  }
+
+  getProvider() {
+    const grammarScopes = atom.config.get(
+      'atom-ide-definitions.clickGrammarScopes'
+    );
+    const priority = atom.config.get('atom-ide-definitions.clickPriority');
+
+    return {
+      priority,
+      // Assign value only if at least one scope is available. Falsey triggers default behaviour, "apply to all".
+      grammarScopes:
+        (grammarScopes && !!grammarScopes[0] && grammarScopes) || null,
+      getSuggestionForWord: this.suggestionForWordHandler,
+    };
+  }
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import { CompositeDisposable } from 'atom';
+import { install as installPackageDependencies } from 'atom-package-deps';
 import goToDefinition from './goToDefinition';
 import createProviderRegistry from './providerRegistry';
 import { ClickProvider } from './clickProvider';
@@ -21,6 +22,8 @@ function package() {
           goToDefinition(providerRegistry),
       })
     );
+
+    installPackageDependencies('atom-ide-definitions');
   }
 
   function deactivate() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,9 +3,13 @@
 import { CompositeDisposable } from 'atom';
 import goToDefinition from './goToDefinition';
 import createProviderRegistry from './providerRegistry';
+import { ClickProvider } from './clickProvider';
 
 function package() {
   const providerRegistry = createProviderRegistry();
+  const clickProvider = new ClickProvider({
+    clickHandler: () => goToDefinition(providerRegistry),
+  });
   let subscriptions;
 
   function activate() {
@@ -27,7 +31,12 @@ function package() {
     providerRegistry.addProvider(provider);
   }
 
-  return { activate, deactivate, consumeDefinitionsService };
+  return {
+    activate,
+    deactivate,
+    consumeDefinitionsService,
+    getClickProvider: clickProvider.getProvider,
+  };
 }
 
 export default package();

--- a/package-lock.json
+++ b/package-lock.json
@@ -3915,6 +3915,15 @@
         "vscode-languageserver-types": "3.12.0"
       }
     },
+    "atom-package-deps": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-5.0.0.tgz",
+      "integrity": "sha512-C5Z2V68GuZvuLowrqQ8O8+BE8P4Elhxuc6eZiZ0770CH2e2R/Ausz5VebbDxVOSedFwAaz3CzQJYHayqZ5wKQg==",
+      "requires": {
+        "sb-fs": "^3.0.0",
+        "semver": "^5.6.0"
+      }
+    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -5609,6 +5618,11 @@
       "requires": {
         "text-extensions": "^1.0.0"
       }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -10200,6 +10214,20 @@
         "ret": "~0.1.10"
       }
     },
+    "sb-fs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sb-fs/-/sb-fs-3.0.0.tgz",
+      "integrity": "sha1-+9zdMBDoChuOJ0kM7zNgZJdCA7g=",
+      "requires": {
+        "sb-promisify": "^2.0.1",
+        "strip-bom-buf": "^1.0.0"
+      }
+    },
+    "sb-promisify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sb-promisify/-/sb-promisify-2.0.2.tgz",
+      "integrity": "sha1-QnelR1RIiqlnXYhuNU24lMm9yYE="
+    },
     "semantic-release": {
       "version": "15.13.3",
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.3.tgz",
@@ -10360,8 +10388,7 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -10737,6 +10764,14 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
+    },
+    "strip-bom-buf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+      "requires": {
+        "is-utf8": "^0.2.1"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "atom-ide",
     "defintion"
   ],
-  "activationCommands": {
-    "atom-workspace": "atom-ide-go-to-definition:go-to-definition"
-  },
   "repository": "https://github.com/atom-ide-community/atom-ide-definitions",
   "license": "MIT",
   "engines": {
@@ -48,6 +45,32 @@
     "definitions": {
       "versions": {
         "0.1.0": "consumeDefinitionsService"
+      }
+    }
+  },
+  "providedServices": {
+    "hyperclick": {
+      "versions": {
+        "0.1.0": "getClickProvider"
+      }
+    }
+  },
+  "configSchema": {
+    "clickPriority": {
+      "order": 1,
+      "title": "Hyperclick Provider Priority",
+      "description": "Provider priority relative to other providers. For more details see [Hyperclick's provider documentation](https://github.com/facebookarchive/hyperclick#details).",
+      "type": "number",
+      "default": 0
+    },
+    "clickGrammarScopes": {
+      "order": 2,
+      "title": "Hyperclick Grammar Scopes",
+      "description": "List of scopes to allow action on. For example, `source.js, source.ts, source.go` *Requires reload to take effect.*",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
+    "atom-package-deps": "^5.0.0",
     "atom-languageclient": "^0.9.9"
   },
   "devDependencies": {
@@ -41,6 +42,9 @@
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
+  "package-deps": [
+    "hyperclick"
+  ],
   "consumedServices": {
     "definitions": {
       "versions": {

--- a/spec/atom-ide-click-spec.js
+++ b/spec/atom-ide-click-spec.js
@@ -22,9 +22,8 @@ describe('AtomIdeClick', () => {
       return config[value];
     });
 
-    spyOn(atom.views, 'getView').andReturn('FakeEditorView');
-
     spyOn(clickHandlers, 'goToDefinitions');
+
     clickProvider = new ClickProvider({
       clickHandler: clickHandlers.goToDefinitions,
     });

--- a/spec/atom-ide-click-spec.js
+++ b/spec/atom-ide-click-spec.js
@@ -1,0 +1,74 @@
+'use babel';
+
+import { ClickProvider } from '../lib/clickProvider';
+
+// Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
+//
+// To run a specific `it` or `describe` block add an `f` to the front (e.g. `fit`
+// or `fdescribe`). Remove the `f` to unfocus the block.
+
+let clickProvider;
+const clickHandlers = {
+  goToDefinitions: () => {},
+};
+
+describe('AtomIdeClick', () => {
+  beforeEach(function() {
+    spyOn(atom.config, 'get').andCallFake(function(value) {
+      const config = {
+        'atom-ide-definitions.clickGrammarScopes': [],
+        'atom-ide-definitions.clickPriority': 0,
+      };
+      return config[value];
+    });
+
+    spyOn(atom.views, 'getView').andReturn('FakeEditorView');
+
+    spyOn(clickHandlers, 'goToDefinitions');
+    clickProvider = new ClickProvider({
+      clickHandler: clickHandlers.goToDefinitions,
+    });
+  });
+
+  it('verify provider result', () => {
+    const provider = clickProvider.getProvider();
+
+    expect(provider.priority).toEqual(0);
+    expect(provider.grammarScopes).toBeNull();
+    expect(typeof provider.getSuggestionForWord).toEqual('function');
+  });
+
+  it('verify suggestionForWord result', () => {
+    const suggestionForWord = clickProvider.suggestionForWordHandler(
+      'FakeEditor',
+      'FakeText',
+      'FakeRange'
+    );
+
+    expect(suggestionForWord.range).toEqual('FakeRange');
+    expect(typeof suggestionForWord.callback).toEqual('function');
+  });
+
+  it('verify suggestionForWord handler stops if there is no text value', () => {
+    const suggestionForWord = clickProvider.suggestionForWordHandler(
+      'FakeEditor',
+      '',
+      'FakeRange'
+    );
+
+    expect(suggestionForWord).toBeUndefined();
+  });
+
+  it('verify suggestionForWord callback assignment', () => {
+    const suggestionForWord = clickProvider.suggestionForWordHandler(
+      'FakeEditor',
+      'FakeText',
+      'FakeRange'
+    );
+
+    expect(typeof suggestionForWord.callback).toEqual('function');
+
+    suggestionForWord.callback();
+    expect(clickHandlers.goToDefinitions).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds [Hyperclick](https://atom.io/packages/hyperclick) provider, allowing "go to definition" to be used through `ctrl/cmd + click` combination.