### PR TITLE
fix hyperclick provider

### DIFF
--- a/lib/goToDefinition.js
+++ b/lib/goToDefinition.js
@@ -49,6 +49,9 @@ export async function getDefinitions(
   const position = targetPosition || editor.getCursorBufferPosition();
 
   const provider = providerRegistry.getProviderForEditor(editor);
+  if (!provider) {
+    return;
+  }
   const result = await provider.getDefinition(editor, position);
 
   return result && result.definitions;

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,5 +36,5 @@ export function consumeDefinitionsService(provider) {
 }
 
 export function getClickProvider() {
-  return clickProvider.getProvider;
+  return clickProvider.getProvider();
 }

--- a/spec/go-to-definition-spec.js
+++ b/spec/go-to-definition-spec.js
@@ -1,0 +1,20 @@
+/** @babel */
+
+import { getDefinitions } from "../lib/goToDefinition";
+
+// Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
+//
+// To run a specific `it` or `describe` block add an `f` to the front (e.g. `fit`
+// or `fdescribe`). Remove the `f` to unfocus the block.
+
+describe("go to definition", () => {
+  describe("getDefinitions", () => {
+    it("returns undefined if no provider exists for editor", async () => {
+      const providerRegistry = {
+        getProviderForEditor() {}
+      }
+      const definitions = await getDefinitions(providerRegistry, { editor: true, position: true });
+      expect(definitions).toBeUndefined();
+    });
+  });
+});

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -1,0 +1,26 @@
+/** @babel */
+
+import * as main from "../lib/main";
+
+// Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
+//
+// To run a specific `it` or `describe` block add an `f` to the front (e.g. `fit`
+// or `fdescribe`). Remove the `f` to unfocus the block.
+
+describe("main", () => {
+  it("activate", async function () {
+    // Trigger deferred activation
+    atom.packages.triggerDeferredActivationHooks();
+    // Activate activation hook
+    atom.packages.triggerActivationHook("core:loaded-shell-environment");
+
+    await atom.packages.activatePackage("atom-ide-definitions");
+    expect(atom.packages.isPackageLoaded("atom-ide-definitions")).toBeTruthy();
+  });
+
+  it("getClickProvider", () => {
+    const provider = main.getClickProvider();
+
+    expect(typeof provider.getSuggestionForWord).toEqual("function");
+  });
+});


### PR DESCRIPTION
hyperclick provider must be an object not a function that returns an object

I also fixed an issue when there was a definitions provider but not for the current grammar it would throw the error `TypeError: Cannot read property 'getDefinition' of undefined`